### PR TITLE
SCRUM-71 - Refactor prefabs and add configuration for prefab generator

### DIFF
--- a/Assets/DefaultPrefabObjects.asset
+++ b/Assets/DefaultPrefabObjects.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: DefaultPrefabObjects
   m_EditorClassIdentifier: 
   _prefabs:
+  - {fileID: -1849635370616442003, guid: ad41b46d90d46a84db8d7e734165c44d, type: 3}
   - {fileID: 6984334402775360438, guid: b16cdabc3cbb33b408bbfa5d2d51d769, type: 3}
   - {fileID: 904911804816547439, guid: b5685a39846e7174a93b5ea6b4ebf566, type: 3}
   - {fileID: 3053243030962434419, guid: bbe49ee6397870f418a8db281163b19f, type: 3}
@@ -22,16 +23,3 @@ MonoBehaviour:
   - {fileID: 8412306589285422451, guid: 0de53df5b8d4ad54b950eb2130c08bb3, type: 3}
   - {fileID: 2805681668901245417, guid: 1bd839d792dc5df42bdaae65fadfda4a, type: 3}
   - {fileID: 3875465447857652874, guid: 877cf8a0c7d1f624281dbd093469f8ea, type: 3}
-  - {fileID: 8475222101369129519, guid: 8cf33e8e99a9b0c4c8f29ff725650de6, type: 3}
-  - {fileID: 4512293259955182956, guid: 44611030e61220d42ab7c37ba3c0ea92, type: 3}
-  - {fileID: 4512293259955182956, guid: 0d6d0f48b03b17f49a6340103cd9b9d0, type: 3}
-  - {fileID: 611616139817875448, guid: bf5f023b4017a5e41a9815ec5745df3d, type: 3}
-  - {fileID: 4512293259955182956, guid: 35639798ad77fc145871588b25d66259, type: 3}
-  - {fileID: 4512293259955182956, guid: fe2b65b02f0484b41aa8cfa9fbbb0e1d, type: 3}
-  - {fileID: 4512293259955182956, guid: dafef736ca1ae384e9a19eb672843563, type: 3}
-  - {fileID: 4512293259955182956, guid: f32d4c19de900e64cb73cedcb8ba6f70, type: 3}
-  - {fileID: 4512293259955182956, guid: b8017cef39731ba439c70fecc09488e3, type: 3}
-  - {fileID: 201277550, guid: 5b712878ecece354ba4ffb026c0a221c, type: 3}
-  - {fileID: 201277550, guid: 26a567abbe21227428f5c3d309d1d73c, type: 3}
-  - {fileID: 8192566354860284824, guid: 6331b3542e64a564c81bc39cedf70c8d, type: 3}
-  - {fileID: -1849635370616442003, guid: ad41b46d90d46a84db8d7e734165c44d, type: 3}

--- a/Assets/FishNet.Config.XML
+++ b/Assets/FishNet.Config.XML
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ConfigurationData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Loaded>false</Loaded>
+  <PrefabGenerator>
+    <Enabled>true</Enabled>
+    <LogToConsole>true</LogToConsole>
+    <FullRebuild>false</FullRebuild>
+    <SpawnableOnly>true</SpawnableOnly>
+    <SaveChanges>true</SaveChanges>
+    <DefaultPrefabObjectsPath>Assets\DefaultPrefabObjects.asset</DefaultPrefabObjectsPath>
+    <SearchScope>1</SearchScope>
+    <ExcludedFolders />
+    <IncludedFolders>
+      <string>Assets\Prefabs</string>
+    </IncludedFolders>
+  </PrefabGenerator>
+  <CodeStripping>
+    <IsBuilding>false</IsBuilding>
+    <IsDevelopment>false</IsDevelopment>
+    <IsHeadless>false</IsHeadless>
+    <StripReleaseBuilds>false</StripReleaseBuilds>
+    <StrippingType>0</StrippingType>
+  </CodeStripping>
+  <CreateNewNetworkBehaviour>
+    <templateDirectoryPath>Assets</templateDirectoryPath>
+  </CreateNewNetworkBehaviour>
+</ConfigurationData>

--- a/Assets/FishNet.Config.XML.meta
+++ b/Assets/FishNet.Config.XML.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b8f2b8abb064f9f43a1dc0b13689b2ed
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Bones.prefab
+++ b/Assets/Prefabs/Bones.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 6209352966512977828}
   - component: {fileID: 6572503753976664422}
   - component: {fileID: -1849635370616442003}
+  - component: {fileID: -75483934574442682}
   m_Layer: 0
   m_Name: Bones
   m_TagString: Untagged
@@ -115,7 +116,8 @@ MonoBehaviour:
   <ComponentIndex>k__BackingField: 0
   <PredictedSpawn>k__BackingField: {fileID: 0}
   <PredictedOwner>k__BackingField: {fileID: 0}
-  NetworkBehaviours: []
+  NetworkBehaviours:
+  - {fileID: -75483934574442682}
   InitializedParentNetworkBehaviour: {fileID: 0}
   InitializedNestedNetworkObjects: []
   RuntimeParentNetworkBehaviour: {fileID: 0}
@@ -140,15 +142,30 @@ MonoBehaviour:
   _spectatorInterpolation: 2
   _enableTeleport: 0
   _teleportThreshold: 1
-  <PrefabId>k__BackingField: 65535
+  <PrefabId>k__BackingField: 7
   <SpawnableCollectionId>k__BackingField: 0
   <AssetPathHash>k__BackingField: 5809542930376490659
   <SceneId>k__BackingField: 0
   SerializedTransformProperties:
-    Position: {x: 0, y: 0, z: 0}
-    Rotation: {x: 0, y: 0, z: 0, w: 0}
-    Scale: {x: 0, y: 0, z: 0}
-    IsValid: 0
+    Position: {x: 197.18073, y: 3.6099854, z: 798.18567}
+    Rotation: {x: -0.7071068, y: -0, z: -0, w: 0.7071067}
+    Scale: {x: 100, y: 99.999985, z: 99.999985}
+    IsValid: 1
+--- !u!114 &-75483934574442682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4351147015997587858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a6a39c46bf52104ba8efe3100bce3f7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _componentIndexCache: 0
+  _addedNetworkObject: {fileID: -1849635370616442003}
+  _networkObjectCache: {fileID: -1849635370616442003}
 --- !u!1001 &1558564402756801498
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/WoodLog.prefab
+++ b/Assets/Prefabs/WoodLog.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 3603112812403096430}
   - component: {fileID: 1978401069597958036}
   - component: {fileID: 8412306589285422451}
+  - component: {fileID: 1018871094485073300}
   m_Layer: 0
   m_Name: WoodLog
   m_TagString: Untagged
@@ -115,7 +116,8 @@ MonoBehaviour:
   <ComponentIndex>k__BackingField: 0
   <PredictedSpawn>k__BackingField: {fileID: 0}
   <PredictedOwner>k__BackingField: {fileID: 0}
-  NetworkBehaviours: []
+  NetworkBehaviours:
+  - {fileID: 1018871094485073300}
   InitializedParentNetworkBehaviour: {fileID: 0}
   InitializedNestedNetworkObjects: []
   RuntimeParentNetworkBehaviour: {fileID: 0}
@@ -140,15 +142,30 @@ MonoBehaviour:
   _spectatorInterpolation: 2
   _enableTeleport: 0
   _teleportThreshold: 1
-  <PrefabId>k__BackingField: 65535
+  <PrefabId>k__BackingField: 19
   <SpawnableCollectionId>k__BackingField: 0
   <AssetPathHash>k__BackingField: 16153189904123671423
   <SceneId>k__BackingField: 0
   SerializedTransformProperties:
-    Position: {x: 0, y: 0, z: 0}
-    Rotation: {x: 0, y: 0, z: 0, w: 0}
-    Scale: {x: 0, y: 0, z: 0}
-    IsValid: 0
+    Position: {x: 200.07855, y: 3.3192334, z: 797.9061}
+    Rotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+    Scale: {x: 140, y: 140, z: 140}
+    IsValid: 1
+--- !u!114 &1018871094485073300
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3421859495812559835}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a6a39c46bf52104ba8efe3100bce3f7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _componentIndexCache: 0
+  _addedNetworkObject: {fileID: 8412306589285422451}
+  _networkObjectCache: {fileID: 8412306589285422451}
 --- !u!1 &6466788560391326779
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
- Removed multiple prefab entries from `DefaultPrefabObjects.asset` and added a new prefab entry.
- Updated `Bones.prefab` and `WoodLog.prefab` by removing several components and adding a new `NetworkBehaviour` to enhance networking capabilities.
- Created `FishNet.Config.XML` for managing prefab generation settings, including logging and rebuild options.
- Added metadata file `FishNet.Config.XML.meta` for the new configuration file.